### PR TITLE
Add Butterworth prototype filters

### DIFF
--- a/prototypes/butterworth/__init__.py
+++ b/prototypes/butterworth/__init__.py
@@ -1,0 +1,14 @@
+from .rc_lowpass import RCLowPass
+from .rc_highpass import RCHighPass
+from .rc_2ndorder_highpass import RC2ndOrderHighPass
+from .rc_2ndorder_lowpass import RC2ndOrderLowPass
+from .rc_1st2ndorder_bandpass import RCBandPass1st, RCBandPass2nd
+
+__all__ = [
+    "RCLowPass",
+    "RCHighPass",
+    "RC2ndOrderHighPass",
+    "RC2ndOrderLowPass",
+    "RCBandPass1st",
+    "RCBandPass2nd",
+]

--- a/prototypes/butterworth/rc_1st2ndorder_bandpass.py
+++ b/prototypes/butterworth/rc_1st2ndorder_bandpass.py
@@ -1,0 +1,238 @@
+# Import needed libraries
+from typing import Iterable
+import numpy as np
+import matplotlib.pyplot as plt
+from pywdf.core.circuit import Circuit
+
+# Import the low-pass and high-pass filters already created
+from .rc_lowpass import RCLowPass
+from .rc_highpass import RCHighPass
+
+class RCBandPass1st(Circuit):
+    """First-order RC band-pass filter implemented by cascading high-pass and low-pass filters.
+   
+    Parameters
+    ----------
+    sample_rate : int
+        Sampling frequency in hertz.
+    center_freq : float
+        Center frequency of the band-pass filter in hertz.
+    bandwidth_octaves : float, optional
+        Bandwidth of the filter in octaves. Default: 1.0
+    apply_auto_gain : bool, optional
+        Whether to apply automatic gain compensation. Default: True
+    """
+    
+    def __init__(self, sample_rate: int, center_freq: float, 
+                 bandwidth_octaves: float = 1.0, apply_auto_gain: bool = True):
+        self.fs = float(sample_rate)
+        self.center_freq = 0.0  
+        self.bandwidth_octaves = max(0.1, bandwidth_octaves)  
+        self.apply_auto_gain = apply_auto_gain
+
+        # Note: initial cutoff values will be updated in set_center_freq()
+        self.hp_stage = RCHighPass(sample_rate, 1000.0)  
+        self.lp_stage = RCLowPass(sample_rate, 1000.0)   
+
+        super().__init__(source=self.hp_stage.Vs, root=self.hp_stage.Vs, output=self.lp_stage.C1)
+
+        self.set_center_freq(center_freq)
+    
+    def prepare(self, new_fs: float) -> None:
+        """Change sample-rate on the fly."""
+        if self.fs != new_fs:
+            self.fs = new_fs
+            self.hp_stage.prepare(new_fs)
+            self.lp_stage.prepare(new_fs)
+            self._update_cutoffs()
+    
+    def set_center_freq(self, fc: float) -> None:
+        """Set the center frequency of the band-pass filter."""
+        if fc <= 0:
+            raise ValueError("Center frequency must be positive")
+        
+        # Limit frequency to valid range (same as C++ implementation)
+        fc = max(20.0, min(self.fs * 0.45, fc))
+        
+        if self.center_freq != fc:
+            self.center_freq = fc
+            self._update_cutoffs()
+    
+    def set_bandwidth(self, octaves: float) -> None:
+        """Set the bandwidth in octaves."""
+        if octaves <= 0:
+            raise ValueError("Bandwidth must be positive")
+        
+        octaves = max(0.1, octaves)  
+        
+        if self.bandwidth_octaves != octaves:
+            self.bandwidth_octaves = octaves
+            self._update_cutoffs()
+    
+    def get_center_freq(self) -> float:
+        """Get the current center frequency."""
+        return self.center_freq
+    
+    def get_bandwidth(self) -> float:
+        """Get the current bandwidth in octaves."""
+        return self.bandwidth_octaves
+    
+    def _update_cutoffs(self) -> None:
+        """Calculate and update the cutoff frequencies for HP and LP stages."""
+        # Calculate the ratio based on bandwidth in octaves (same as C++ implementation)
+        ratio = 2.0 ** (self.bandwidth_octaves / 2.0)
+        
+        # For a bandpass:
+        # - high-pass cutoff is below the center frequency
+        # - low-pass cutoff is above the center frequency
+        hp_cutoff = self.center_freq / ratio
+        lp_cutoff = self.center_freq * ratio
+
+        hp_cutoff = max(20.0, min(self.fs * 0.45, hp_cutoff))
+        lp_cutoff = max(20.0, min(self.fs * 0.45, lp_cutoff))
+
+        self.hp_stage.set_cutoff(hp_cutoff)
+        self.lp_stage.set_cutoff(lp_cutoff)
+    
+    def process_sample(self, x: float) -> float:
+        """Process a single audio sample through the band-pass filter."""
+        # Apply auto-gain if enabled (same factor as C++ implementation)
+        if self.apply_auto_gain:
+            x *= 1.5
+
+        hp_output = self.hp_stage.process_sample(x)
+        bp_output = self.lp_stage.process_sample(hp_output)
+        
+        return bp_output
+    
+    def process_block(self, block: Iterable[float]) -> np.ndarray:
+        """Process a block of audio samples."""
+        return np.fromiter((self.process_sample(x) for x in block), dtype=float)
+    
+    def reset(self) -> None:
+        """Reset the internal state of both filter stages."""
+        self.hp_stage.reset()
+        self.lp_stage.reset()
+
+
+class RCBandPass2nd(Circuit):
+    """Second-order RC band-pass filter with steeper roll-off slopes.
+    
+    Parameters
+    ----------
+    sample_rate : int
+        Sampling frequency in hertz.
+    center_freq : float
+        Center frequency of the band-pass filter in hertz.
+    bandwidth_octaves : float, optional
+        Bandwidth of the filter in octaves. Default: 1.0
+    apply_auto_gain : bool, optional
+        Whether to apply automatic gain compensation. Default: True
+    """
+    
+    def __init__(self, sample_rate: int, center_freq: float,
+                 bandwidth_octaves: float = 1.0, apply_auto_gain: bool = True):
+        self.fs = float(sample_rate)
+        self.center_freq = 0.0
+        self.bandwidth_octaves = max(0.1, bandwidth_octaves)
+        self.apply_auto_gain = apply_auto_gain
+        
+        # Create two cascaded stages for each filter type
+        self.hp_stage1 = RCHighPass(sample_rate, 1000.0)
+        self.hp_stage2 = RCHighPass(sample_rate, 1000.0)
+        self.lp_stage1 = RCLowPass(sample_rate, 1000.0)
+        self.lp_stage2 = RCLowPass(sample_rate, 1000.0)
+        
+        super().__init__(source=self.hp_stage1.Vs, root=self.hp_stage1.Vs, output=self.lp_stage2.C1)
+        
+        self.set_center_freq(center_freq)
+    
+    def prepare(self, new_fs: float) -> None:
+        """Change sample-rate on the fly."""
+        if self.fs != new_fs:
+            self.fs = new_fs
+            self.hp_stage1.prepare(new_fs)
+            self.hp_stage2.prepare(new_fs)
+            self.lp_stage1.prepare(new_fs)
+            self.lp_stage2.prepare(new_fs)
+            self._update_cutoffs()
+    
+    def set_center_freq(self, fc: float) -> None:
+        """Set the center frequency of the band-pass filter."""
+        if fc <= 0:
+            raise ValueError("Center frequency must be positive")
+        
+        fc = max(20.0, min(self.fs * 0.45, fc))
+        
+        if self.center_freq != fc:
+            self.center_freq = fc
+            self._update_cutoffs()
+    
+    def set_bandwidth(self, octaves: float) -> None:
+        """Set the bandwidth in octaves."""
+        if octaves <= 0:
+            raise ValueError("Bandwidth must be positive")
+        
+        octaves = max(0.1, octaves)
+        
+        if self.bandwidth_octaves != octaves:
+            self.bandwidth_octaves = octaves
+            self._update_cutoffs()
+    
+    def get_center_freq(self) -> float:
+        """Get the current center frequency."""
+        return self.center_freq
+    
+    def get_bandwidth(self) -> float:
+        """Get the current bandwidth in octaves."""
+        return self.bandwidth_octaves
+    
+    def _update_cutoffs(self) -> None:
+        """Calculate and update the cutoff frequencies for all filter stages."""
+        ratio = 2.0 ** (self.bandwidth_octaves / 2.0)
+        
+        hp_cutoff = self.center_freq / ratio
+        lp_cutoff = self.center_freq * ratio
+
+        hp_cutoff = max(20.0, min(self.fs * 0.45, hp_cutoff))
+        lp_cutoff = max(20.0, min(self.fs * 0.45, lp_cutoff))
+
+        self.hp_stage1.set_cutoff(hp_cutoff)
+        self.hp_stage2.set_cutoff(hp_cutoff)
+        self.lp_stage1.set_cutoff(lp_cutoff)
+        self.lp_stage2.set_cutoff(lp_cutoff)
+    
+    def process_sample(self, x: float) -> float:
+        """Process a single audio sample through the second-order band-pass filter."""
+        if self.apply_auto_gain:
+            x *= 2.23
+
+        x = self.hp_stage1.process_sample(x)
+        x = self.hp_stage2.process_sample(x)
+        x = self.lp_stage1.process_sample(x)
+        x = self.lp_stage2.process_sample(x)
+        
+        return x
+    
+    def process_block(self, block: Iterable[float]) -> np.ndarray:
+        """Process a block of audio samples."""
+        return np.fromiter((self.process_sample(x) for x in block), dtype=float)
+    
+    def reset(self) -> None:
+        """Reset the internal state of all filter stages."""
+        self.hp_stage1.reset()
+        self.hp_stage2.reset()
+        self.lp_stage1.reset()
+        self.lp_stage2.reset()
+
+
+# Testing
+if __name__ == "__main__":
+
+    print("Testing RCBandPass1st")
+    bp1 = RCBandPass1st(sample_rate=48_000, center_freq=1000, bandwidth_octaves=1.0)
+    bp1.plot_freqz()
+    
+    print("Testing RCBandPass2nd")
+    bp2 = RCBandPass2nd(sample_rate=48_000, center_freq=1000, bandwidth_octaves=1.0)
+    bp2.plot_freqz()

--- a/prototypes/butterworth/rc_2ndorder_highpass.py
+++ b/prototypes/butterworth/rc_2ndorder_highpass.py
@@ -1,0 +1,98 @@
+from typing import Iterable
+import numpy as np
+
+# Import the 1st‑order section we already created
+from prototypes.src.rc_highpass import RCHighPass
+
+__all__ = ["RC2ndOrderHighPass"]
+
+
+class RC2ndOrderHighPass:
+    """Second‑order RC high‑pass filter.
+
+    Two identical first‑order sections are cascaded.  To obtain a −3 dB
+    cutoff at *fc* **for the overall response**, every individual section has
+    to be tuned a bit *above* *fc* (otherwise the cascade would be −6 dB at
+    the nominal frequency).
+
+    Maths (normalised):
+        |H₁(jω)|² = ω² / (1+ω²)  →  one stage ⇒ −3 dB at ω = 1
+        |H(jω)|²  = |H₁|⁴        →  cascade
+        We want |H(jωc)| = 1/√2 ⇒ |H₁| = 2^{-1/4}
+        Solve  ωc²/(1+ωc²) = 2^{-1/2} ⇒  ωc ≈ 1.553.
+
+    Therefore: fc_section ≈ 1.553 · fc_target.
+    Constant  *K = 1.553* is coded below.
+    """
+
+    _K = 1.553  # section‑frequency multiplier for Butterworth alignment
+
+    # ---------------------------------------------------------------------
+    # construction helpers
+    # ---------------------------------------------------------------------
+    def __init__(self, sample_rate: int, cutoff: float) -> None:
+        """Create a 2nd‑order high‑pass.
+
+        Parameters
+        ----------
+        sample_rate : int
+            Processing sample‑rate (Hz).
+        cutoff : float
+            Desired overall −3 dB cutoff frequency (Hz).
+        """
+        self.fs = sample_rate
+        self.cutoff = cutoff
+
+        # Create two cascaded first‑order high‑pass sections.  Each one is
+        # tuned *above* the target fc.
+        fc_section = self._K * cutoff
+        self._stage1 = RCHighPass(sample_rate, fc_section)
+        self._stage2 = RCHighPass(sample_rate, fc_section)
+
+    # ------------------------------------------------------------------
+    # framework‑style API (prepare, set_param, processing)  --------------
+    # ------------------------------------------------------------------
+    def prepare(self, new_fs: int) -> None:
+        """Change sample‑rate on the fly."""
+        if new_fs != self.fs:
+            self.fs = new_fs
+            self._stage1.set_sample_rate(new_fs)
+            self._stage2.set_sample_rate(new_fs)
+
+    def set_cutoff(self, new_cutoff: float) -> None:
+        """Retune both sections so that the *overall* cutoff becomes
+        *new_cutoff*.
+        """
+        if new_cutoff != self.cutoff:
+            # Clamp cutoff and translate for the cascaded sections
+            new_cutoff = max(20.0, min(self.fs * 0.45, new_cutoff))
+            self.cutoff = new_cutoff
+            fc_section = self._K * new_cutoff
+            self._stage1.set_cutoff(fc_section)
+            self._stage2.set_cutoff(fc_section)
+
+    # ------------------------------------------------------------------
+    # processing helpers  ----------------------------------------------
+    # ------------------------------------------------------------------
+    def process_sample(self, x: float) -> float:
+        """Process a single‑channel sample."""
+        return self._stage2.process_sample(self._stage1.process_sample(x))
+
+    def process_block(self, block: Iterable[float]) -> np.ndarray:
+        """Process an iterable of samples (list, numpy array, etc.)."""
+        y = np.empty(len(block), dtype=float)
+        for n, s in enumerate(block):
+            y[n] = self.process_sample(float(s))
+        return y
+
+    # Convenience wrappers re‑exposing analysis utilities from Stage 2
+    # (Stage 2 already includes IR and freq‑response helpers through Circuit)
+    # ------------------------------------------------------------------
+    def plot_freqz(self, *args, **kwargs):
+        self._stage2.plot_freqz(*args, **kwargs)
+
+    def plot_impulse_response(self, *args, **kwargs):
+        self._stage2.plot_impulse_response(*args, **kwargs)
+
+    def AC_transient_analysis(self, *args, **kwargs):
+        self._stage2.AC_transient_analysis(*args, **kwargs)

--- a/prototypes/butterworth/rc_2ndorder_lowpass.py
+++ b/prototypes/butterworth/rc_2ndorder_lowpass.py
@@ -1,0 +1,57 @@
+from typing import Iterable
+import numpy as np
+
+from .rc_lowpass import RCLowPass
+
+__all__ = ["RC2ndOrderLowPass"]
+
+
+class RC2ndOrderLowPass:
+    """Second-order RC low-pass filter.
+
+    Two first-order low-pass sections are cascaded. Each stage is tuned
+    above the desired overall cutoff using the same Butterworth
+    alignment constant as the high-pass version.
+    """
+
+    _K = 1.553  # section-frequency multiplier for Butterworth alignment
+
+    def __init__(self, sample_rate: int, cutoff: float) -> None:
+        self.fs = sample_rate
+        self.cutoff = cutoff
+
+        fc_section = self._K * cutoff
+        self._stage1 = RCLowPass(sample_rate, fc_section)
+        self._stage2 = RCLowPass(sample_rate, fc_section)
+
+    def prepare(self, new_fs: int) -> None:
+        if new_fs != self.fs:
+            self.fs = new_fs
+            self._stage1.prepare(new_fs)
+            self._stage2.prepare(new_fs)
+
+    def set_cutoff(self, new_cutoff: float) -> None:
+        if new_cutoff != self.cutoff:
+            new_cutoff = max(20.0, min(self.fs * 0.45, new_cutoff))
+            self.cutoff = new_cutoff
+            fc_section = self._K * new_cutoff
+            self._stage1.set_cutoff(fc_section)
+            self._stage2.set_cutoff(fc_section)
+
+    def process_sample(self, x: float) -> float:
+        return self._stage2.process_sample(self._stage1.process_sample(x))
+
+    def process_block(self, block: Iterable[float]) -> np.ndarray:
+        y = np.empty(len(block), dtype=float)
+        for n, s in enumerate(block):
+            y[n] = self.process_sample(float(s))
+        return y
+
+    def plot_freqz(self, *args, **kwargs):
+        self._stage2.plot_freqz(*args, **kwargs)
+
+    def plot_impulse_response(self, *args, **kwargs):
+        self._stage2.plot_impulse_response(*args, **kwargs)
+
+    def AC_transient_analysis(self, *args, **kwargs):
+        self._stage2.AC_transient_analysis(*args, **kwargs)

--- a/prototypes/butterworth/rc_highpass.py
+++ b/prototypes/butterworth/rc_highpass.py
@@ -1,0 +1,142 @@
+from typing import Iterable, List
+import numpy as np
+
+# Import pywdf primitives. Adjust the import path if your repo layout is different.
+from pywdf.core.wdf import (
+    Resistor,
+    Capacitor,
+    SeriesAdaptor,
+    ParallelAdaptor,
+    ResistiveVoltageSource,
+)
+from pywdf.core.circuit import Circuit
+
+
+class RCHighPass(Circuit):
+    """First‑order RC high‑pass filter implemented with Wave‑Digital elements.
+
+    Parameters
+    ----------
+    fs : int
+        Sampling frequency in hertz.
+    cutoff : float
+        Desired −3 dB cut‑off frequency in hertz.
+    r_source : float, optional
+        Internal resistance of the driving source (Ω). Default: ``75``.
+    r_series : float, optional
+        Extra series resistor in front of the capacitor (Ω). Default: ``1000``.
+    r_load : float, optional
+        Load/probe resistance where the output is taken (Ω). Default: ``10000``.
+    """
+
+    def __init__(
+        self,
+        fs: int,
+        cutoff: float,
+        r_source: float = 75.0,
+        r_series: float = 1_000.0,
+        r_load: float = 10_000.0,
+    ) -> None:
+        # Public parameters
+        self.fs = fs
+        self.r_source = float(r_source)
+        self.r_series = float(r_series)
+        self.r_load = float(r_load)
+
+        # Wave‑digital components (place‑holders typed for IDEs)
+        self.R_load: Resistor
+        self.C: Capacitor
+        self.R_series: Resistor
+        self.Vs: ResistiveVoltageSource
+        self.S1: SeriesAdaptor  # source series adaptor
+        self.P1: ParallelAdaptor  # R‑par‑C adaptor
+        self.S2: SeriesAdaptor  # C‑R_load series adaptor
+
+        # Build the network and register it with Circuit
+        self._build_network()
+        super().__init__(self.Vs, self.Vs, self.R_load)
+
+        # Initialise the user parameter last so that Rp is correct
+        self.set_cutoff(cutoff)
+
+    # ---------------------------------------------------------------------
+    # Internal helpers
+    # ---------------------------------------------------------------------
+
+    def _build_network(self) -> None:
+        """Instantiate WDF elements and wire them in the SPQR tree."""
+        # Passive elements
+        self.R_load = Resistor(self.r_load)
+        self.C = Capacitor(1e-9, self.fs)  # dummy value – will be set later
+        self.R_series = Resistor(self.r_series)
+
+        # Build adaptors that mirror the analogue topology
+        # (R_load)––S2––(C)     <= series
+        self.S2 = SeriesAdaptor(self.R_load, self.C)
+        # (S2 branch) || (R_series)  <= parallel
+        self.P1 = ParallelAdaptor(self.S2, self.R_series)
+
+        # Voltage source with source impedance in series (Vs)
+        self.Vs = ResistiveVoltageSource(self.r_source)
+        self.S1 = SeriesAdaptor(self.P1, self.Vs)
+
+    # ---------------------------------------------------------------------
+    # Public API – lifecycle
+    # ---------------------------------------------------------------------
+
+    def prepare(self, new_fs: int) -> None:
+        """Re‑initialise the filter for a new sample‑rate."""
+        super().set_sample_rate(new_fs)
+
+    # ---------------------------------------------------------------------
+    # Public API – parameters
+    # ---------------------------------------------------------------------
+
+    def set_cutoff(self, fc: float) -> None:
+        """Set the −3 dB cut‑off frequency (Hz)."""
+        if fc <= 0:
+            raise ValueError("cutoff must be greater than 0 Hz")
+
+        # Avoid unnecessary recalculation
+        if getattr(self, "cutoff", None) == fc:
+            return
+
+        # Clamp cutoff to a sensible range
+        fc = max(20.0, min(self.fs * 0.45, fc))
+
+        self.cutoff = fc
+        # High‑pass RC: C = 1/(2π R_load fc)
+        c_val = 1.0 / (2.0 * np.pi * self.r_load * fc)
+        self.C.set_capacitance(c_val)
+
+    # Aliasing for a generic host (e.g. JUCE parameter IDs)
+    set_param = set_cutoff
+
+    # ---------------------------------------------------------------------
+    # Audio processing
+    # ---------------------------------------------------------------------
+
+    def process_sample(self, x: float) -> float:
+        """Process and return one audio sample."""
+        # 1. Drive source with input voltage
+        self.Vs.set_voltage(x)
+
+        # 2. Wave‑up: propagate b from the filter towards the source
+        self.Vs.accept_incident_wave(self.S1.propagate_reflected_wave())
+
+        # 3. Wave‑down: propagate the updated a from the source to the filter
+        self.S1.accept_incident_wave(self.Vs.propagate_reflected_wave())
+
+        # 4. Output – voltage across the load resistor
+        return self.R_load.wave_to_voltage()
+
+    # Convenience vector version (not needed by JUCE later, but handy in Python)
+    def process_block(self, block: Iterable[float]) -> np.ndarray:
+        """Process an iterable of samples and return a NumPy array."""
+        return np.fromiter((self.process_sample(s) for s in block), dtype=float)
+
+
+# Optional: tiny self‑test
+if __name__ == "__main__":
+    hp = RCHighPass(fs=48_000, cutoff=1_000)
+    hp.plot_freqz()

--- a/prototypes/butterworth/rc_lowpass.py
+++ b/prototypes/butterworth/rc_lowpass.py
@@ -1,0 +1,117 @@
+from typing import Iterable
+import numpy as np
+
+# Adjust these imports to your package structure if necessary
+from pywdf.core.wdf import (
+    Resistor,
+    Capacitor,
+    SeriesAdaptor,
+    PolarityInverter,
+    IdealVoltageSource,
+)
+from pywdf.core.circuit import Circuit
+
+
+class RCLowPass(Circuit):
+    """First‑order RC low‑pass filter implemented with Wave‑Digital elements.
+
+    The analogue reference topology is a series resistor feeding a shunt
+    capacitor.  The output is taken across the capacitor so DC passes and
+    high frequencies are attenuated at –6 dB/oct (–20 dB/dec). The WDF
+    version mirrors that: R and C connected via a *SeriesAdaptor*, output
+    taken from the capacitor’s port.
+    """
+
+    # ─────────────────────────── construction ────────────────────────────
+    def __init__(self, sample_rate: int, cutoff_hz: float) -> None:
+        self.fs: float = float(sample_rate)
+        self._cutoff = 0.0  # will be set properly in set_cutoff()
+
+        # Default element values (will be adapted by set_cutoff)
+        self.C_val: float = 1e-6  # Farads
+        self.R_val: float = 1.0  # Ohms, placeholder until set_cutoff()
+
+        # WDF elements ----------------------------------------------------
+        self.R1 = Resistor(self.R_val)
+        self.C1 = Capacitor(self.C_val, self.fs)
+
+        # R‑C in series (same current) – adaptor takes care of waves
+        self.S1 = SeriesAdaptor(self.R1, self.C1)
+
+        # Polarity inverter ensures the low‑pass has positive gain (same as
+        # using the bottom node of C as reference in the analogue diagram).
+        self.inv = PolarityInverter(self.S1)
+
+        # Voltage source is the root (driver) of the WDF tree
+        self.Vs = IdealVoltageSource(self.inv)
+
+        # Call base class constructor: source, root, output‑probe
+        super().__init__(source=self.Vs, root=self.Vs, output=self.C1)
+
+        # Finally set the requested fc
+        self.set_cutoff(cutoff_hz)
+
+    # ─────────────────────────── parameters ──────────────────────────────
+    def prepare(self, new_fs: float) -> None:
+        """Change sample‑rate on the fly (e.g. if host changes).
+        Propagates the new *fs* to every element that stores it."""
+        if self.fs != new_fs:
+            self.fs = new_fs
+            self.C1.prepare(new_fs)
+            # R has no fs‑dependent impedance, nothing to do.
+
+    # Public accessor -----------------------------------------------------
+    @property
+    def cutoff(self) -> float:
+        return self._cutoff
+
+    def set_cutoff(self, cutoff_hz: float) -> None:
+        """Update cut‑off frequency (Hz) at run‑time.
+
+        The relation for a 1st‑order RC low‑pass is fc = 1/(2π R C).
+        We keep *C* fixed and solve for *R* so we only need to update one
+        element’s impedance and avoid re‑allocating memory.
+        """
+        if cutoff_hz <= 0:
+            raise ValueError("Cut‑off frequency must be positive")
+
+        # Clamp cutoff to a sensible range
+        cutoff_hz = max(20.0, min(self.fs * 0.45, cutoff_hz))
+
+        if self._cutoff != cutoff_hz:
+            self._cutoff = cutoff_hz
+            self.R_val = 1.0 / (2.0 * np.pi * self.C_val * cutoff_hz)
+            self.R1.set_resistance(self.R_val)
+
+    # ─────────────────────────── processing ──────────────────────────────
+    def process_sample(self, x_n: float) -> float:
+        """Real‑time, sample‑by‑sample processing entry point."""
+        self.Vs.set_voltage(x_n)
+
+        # wave‑up from adaptor to source
+        self.Vs.accept_incident_wave(self.inv.propagate_reflected_wave())
+        # wave‑down from source back into network
+        self.inv.accept_incident_wave(self.Vs.propagate_reflected_wave())
+
+        return self.C1.wave_to_voltage()
+
+    # More DAW‑friendly block API ----------------------------------------
+    def process_block(self, block: Iterable[float]) -> np.ndarray:
+        """Vectorised helper that just loops `process_sample`.
+
+        Provided for convenience so the same module works in scripts and
+        in real‑time hosts that deliver buffers.
+        """
+        self.reset()  # clear state between unrelated calls if needed
+        return np.fromiter((self.process_sample(x) for x in block), dtype=float)
+
+
+# ────────────────────────────── demo ─────────────────────────────────────
+if __name__ == "__main__":  # Quick sanity‑check when run as script
+    import matplotlib.pyplot as plt
+
+    lpf = RCLowPass(sample_rate=48_000, cutoff_hz=1000)
+    lpf.plot_freqz()
+
+    # Uncomment to see parameter sweep
+    # lpf.plot_freqz_list(range(500, 5000, 500), lpf.set_cutoff, "fc")


### PR DESCRIPTION
## Summary
- add Butterworth prototype filters under `prototypes/butterworth`
- clamp cutoff frequency for all filters
- add second-order low-pass class
- replicate bandpass modules using these classes
- expose new classes from package

## Testing
- `python3 -m py_compile prototypes/butterworth/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684af6a67ab0833283aeab0a39e9ff42